### PR TITLE
Upgrade workshop to 2.2.0 stable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ build-linter
 
 # temporary release files
 release/
+
+# checkpoint directory
+checkpoint-dir/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ververica/flink-statefun:2.1.0
+FROM ververica/flink-statefun:2.2.0
 
-RUN mkdir -p /opt/statefun/modules/statefun-workshop-protocol
-RUN mkdir -p /opt/statefun/modules/statefun-workshop-io
-RUN mkdir -p /opt/statefun/modules/statefun-workshop-functions
-RUN mkdir -p /opt/statefun/modules/model
+RUN mkdir -p /opt/statefun/modules/statefun-workshop-protocol; \
+    mkdir -p /opt/statefun/modules/statefun-workshop-io; \
+    mkdir -p /opt/statefun/modules/statefun-workshop-functions; \
+    mkdir -p /opt/statefun/modules/model
 
 ADD flink-conf.yaml $FLINK_HOME/conf/flink-conf.yaml
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,9 +19,9 @@ services:
     ports:
     - "8888:8888"
   master:
-    image: ververica/flink-statefun-training:1.0.0
+    image: ververica/flink-statefun-training:1.1.0
     # uncomment build line to rebuild the image
-    #build: .
+    build: .
     # uncomment and adjust savepoint path to start from a savepoint
     #command: -s /savepoint-dir/savepoint-3df90d-aa82d691740f
     expose:
@@ -32,11 +32,11 @@ services:
     - ROLE=master
     - MASTER_HOST=master
     volumes:
-    - ./savepoint-dir:/savepoint-dir
+    - ./checkpoint-dir:/checkpoint-dir
   worker:
-    image: ververica/flink-statefun-training:1.0.0
+    image: ververica/flink-statefun-training:1.1.0
     # uncomment build line to rebuild the image
-    #build: .
+    build: .
     expose:
     - "6121"
     - "6122"
@@ -50,5 +50,5 @@ services:
     - ROLE=worker
     - MASTER_HOST=master
     volumes:
-    - ./savepoint-dir:/savepoint-dir
+    - ./checkpoint-dir:/checkpoint-dir
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   master:
     image: ververica/flink-statefun-training:1.1.0
     # uncomment build line to rebuild the image
-    build: .
+    # build: .
     # uncomment and adjust savepoint path to start from a savepoint
     #command: -s /savepoint-dir/savepoint-3df90d-aa82d691740f
     expose:
@@ -36,7 +36,7 @@ services:
   worker:
     image: ververica/flink-statefun-training:1.1.0
     # uncomment build line to rebuild the image
-    build: .
+    # build: .
     expose:
     - "6121"
     - "6122"

--- a/flink-conf.yaml
+++ b/flink-conf.yaml
@@ -60,13 +60,18 @@ parallelism.default: 1
 
 rest.bind-port: 8001
 
-classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+# Decrease heartbeat timeout. This is set to a very small value
+# for TM failure demonstrations. Do not expect these values to
+# work outside a local setup.
+heartbeat.interval: 1000
+heartbeat.timeout: 5000
 
-jobmanager.scheduler: legacy
+classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
 
 execution.checkpointing.interval: 10s
 
-state.savepoints.dir: file:///savepoint-dir
+state.checkpoints.dir: file:///checkpoint-dir
+state.savepoints.dir: file:///checkpoint-dir/savepoint
 
 # IO configurations
 

--- a/statefun-workshop-python/requirements.txt
+++ b/statefun-workshop-python/requirements.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apache-flink-statefun==2.1.0
+apache-flink-statefun==2.2.0
 flask
 gunicorn==20.0.4


### PR DESCRIPTION
This upgrades the workshop to 2.2.0 stable and also changes the flink-conf so TM failures are noticed more quickly for better checkpoint recovery demonstrations. In the main commit, the docker-compose builds the image locally so it can be tested but I will squash the fixup commit which comments that out when merging as I'll be pushing the image to docker-hub. 