### PR TITLE
fix kafka failing to start on Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     ports:
       - "9092:9092"
     environment:
+      KAFKA_ADVERTISED_HOST_NAME: "kafka-broker"
       HOSTNAME_COMMAND: "route -n | awk '/UG[ \t]/{print $$2}'"
       KAFKA_CREATE_TOPICS: "transactions:1:1,alerts:1:1,confirmed:1:1,thresholds"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181


### PR DESCRIPTION
This properly sets `KAFKA_ADVERTISED_HOST_NAME`. Theoretically, `HOSTNAME_COMMAND` can then go away, but let's leave it in for now and evaluate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/flink-statefun-workshop/7)
<!-- Reviewable:end -->
