### PR TITLE
[FENG-1646] Upgrade StateFun Workshop Exercise to 3.1

### DIFF
--- a/conf/flink-conf.yaml
+++ b/conf/flink-conf.yaml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is the base for the Apache Flink configuration
+
+statefun.flink-job-name: Statefun Application
+
+classloader.parent-first-patterns.additional: org.apache.flink.statefun;org.apache.kafka;com.google.protobuf
+
+restart-strategy: fixed-delay
+restart-strategy.fixed-delay.attempts: 2147483647
+restart-strategy.fixed-delay.delay: 1sec
+
+state.backend: rocksdb
+state.backend.rocksdb.timer-service.factory: ROCKSDB
+state.backend.rocksdb.memory.partitioned-index-filters: true
+state.backend.rocksdb.checkpoint.transfer.thread.num: 8
+state.backend.rocksdb.thread.num: 4
+state.backend.incremental: true
+
+jobmanager.memory.process.size: 1g
+taskmanager.memory.process.size: 4g
+
+heartbeat.interval: 1000
+heartbeat.timeout: 5000
+
+rest.flamegraph.enabled: true
+web.backpressure.refresh-interval: 10000
+statefun.async.max-per-task: 100000
+

--- a/conf/log4j-cli.properties
+++ b/conf/log4j-cli.properties
@@ -1,0 +1,40 @@
+rootLogger.level = INFO
+rootLogger.appenderRef.file.ref = FileAppender
+
+# Log all infos in the given file
+appender.file.name = FileAppender
+appender.file.type = FILE
+appender.file.append = false
+appender.file.fileName = ${sys:log.file}
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# Log output from org.apache.flink.yarn to the console. This is used by the
+# CliFrontend class when using a per-job YARN cluster.
+logger.yarn.name = org.apache.flink.yarn
+logger.yarn.level = INFO
+logger.yarn.appenderRef.console.ref = ConsoleAppender
+logger.yarncli.name = org.apache.flink.yarn.cli.FlinkYarnSessionCli
+logger.yarncli.level = INFO
+logger.yarncli.appenderRef.console.ref = ConsoleAppender
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = INFO
+logger.hadoop.appenderRef.console.ref = ConsoleAppender
+
+# Log output from org.apache.flink.kubernetes to the console.
+logger.kubernetes.name = org.apache.flink.kubernetes
+logger.kubernetes.level = INFO
+logger.kubernetes.appenderRef.console.ref = ConsoleAppender
+
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# suppress the warning that hadoop native libraries are not loaded (irrelevant for the client)
+logger.hadoopnative.name = org.apache.hadoop.util.NativeCodeLoader
+logger.hadoopnative.level = OFF
+
+# Suppress the irrelevant (wrong) warnings from the Netty channel handler
+logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.level = OFF

--- a/conf/log4j-console.properties
+++ b/conf/log4j-console.properties
@@ -1,0 +1,44 @@
+# This affects logging for both user code and Flink
+rootLogger.level = INFO
+rootLogger.appenderRef.console.ref = ConsoleAppender
+rootLogger.appenderRef.rolling.ref = RollingFileAppender
+
+# Uncomment this if you want to _only_ change Flink's logging
+#logger.flink.name = org.apache.flink
+#logger.flink.level = INFO
+
+# The following lines keep the log level of common libraries/connectors on
+# log level INFO. The root logger does not override this. You have to manually
+# change the log levels here.
+logger.akka.name = akka
+logger.akka.level = INFO
+logger.kafka.name= org.apache.kafka
+logger.kafka.level = INFO
+logger.hadoop.name = org.apache.hadoop
+logger.hadoop.level = INFO
+logger.zookeeper.name = org.apache.zookeeper
+logger.zookeeper.level = INFO
+
+# Log all infos to the console
+appender.console.name = ConsoleAppender
+appender.console.type = CONSOLE
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+
+# Log all infos in the given rolling file
+appender.rolling.name = RollingFileAppender
+appender.rolling.type = RollingFile
+appender.rolling.append = false
+appender.rolling.fileName = ${sys:log.file}
+appender.rolling.filePattern = ${sys:log.file}.%i
+appender.rolling.layout.type = PatternLayout
+appender.rolling.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+appender.rolling.policies.type = Policies
+appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
+appender.rolling.policies.size.size=100MB
+appender.rolling.strategy.type = DefaultRolloverStrategy
+appender.rolling.strategy.max = 10
+
+# Suppress the irrelevant (wrong) warnings from the Netty channel handler
+logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.level = OFF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   ###############################################################
 
   statefun-manager:
-    image: apache/flink-statefun:3.0.0
+    image: apache/flink-statefun:3.1.0
     expose:
       - "6123"
     ports:
@@ -35,9 +35,10 @@ services:
       MASTER_HOST: statefun-manager
     volumes:
       - ./module.yaml:/opt/statefun/modules/workshop/module.yaml
+      - ./conf:/opt/flink/conf
 
   statefun-worker:
-    image: apache/flink-statefun:3.0.0
+    image: apache/flink-statefun:3.1.0
     expose:
       - "6121"
       - "6122"
@@ -46,6 +47,7 @@ services:
       MASTER_HOST: statefun-manager
     volumes:
       - ./module.yaml:/opt/statefun/modules/workshop/module.yaml
+      - ./conf:/opt/flink/conf
 
   ###############################################################
   #    Model Function supplied by the Data Science Team

--- a/module.yaml
+++ b/module.yaml
@@ -11,57 +11,45 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-version: "3.0"
-
-module:
-  meta:
-    type: remote
-  spec:
-    endpoints:
-      - endpoint:
-         meta:
-           kind: http
-         spec:
-           functions: com.ververica.fn/*
-           urlPathTemplate: http://host-machine:8100/statefun
-      - endpoint:
-          meta:
-            kind: http
-          spec:
-            functions: com.ververica.ds/*
-            urlPathTemplate: http://model:8900/statefun
-    ingresses:
-      - ingress:
-          meta:
-            type: io.statefun.kafka/ingress
-            id: com.ververica.ingress/Transaction 
-          spec:
-            address: kafka-broker:9092
-            consumerGroupId: transaction-reader
-            topics:
-              - topic: transactions
-                valueType: com.ververica.types/transaction
-                targets:
-                  - com.ververica.fn/transaction-manager
-      - ingress:
-          meta:
-            type: io.statefun.kafka/ingress
-            id: com.ververica.types/confrim-fraud
-          spec:
-            address: kafka-broker:9092
-            consumerGroupId: confirm-fraud-reader
-            topics:
-              - topic: confirmed
-                valueType: com.ververica.types/confirm-fraud
-                targets:
-                  - com.ververica.fn/counter
-    egresses:
-      - egress:
-          meta:
-            type: io.statefun.kafka/egress
-            id: com.ververica.egress/alerts
-          spec:
-            address: kafka-broker:9092
-            deliverySemantic:
-              type: at-least-once
+kind: io.statefun.endpoints.v2/http
+spec:
+  functions: com.ververica.fn/*
+  urlPathTemplate: http://host-machine:8100/statefun
+  transport:
+    type: io.statefun.transports.v1/async
+---
+kind: io.statefun.endpoints.v2/http
+spec:
+  functions: com.ververica.ds/*
+  urlPathTemplate: http://model:8900/statefun
+  transport:
+    type: io.statefun.transports.v1/async
+---
+kind: io.statefun.kafka.v1/ingress
+spec:
+  id: com.ververica.ingress/Transaction
+  address: kafka-broker:9092
+  consumerGroupId: transaction-reader
+  topics:
+  - topic: transactions
+    valueType: com.ververica.types/transaction
+    targets:
+    - com.ververica.fn/transaction-manager
+---
+kind: io.statefun.kafka.v1/ingress
+spec:
+  id: com.ververica.types/confrim-fraud
+  address: kafka-broker:9092
+  consumerGroupId: confirm-fraud-reader
+  topics:
+  - topic: confirmed
+    valueType: com.ververica.types/confirm-fraud
+    targets:
+    - com.ververica.fn/counter
+---
+kind: io.statefun.kafka.v1/egress
+spec:
+  id: com.ververica.egress/alerts
+  address: kafka-broker:9092
+  deliverySemantic:
+    type: at-least-once

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with io.open(os.path.join(this_directory, 'README.md'), 'r', encoding='utf-8') a
 
 setup(
     name='workshop',
-    version='3.0.0',
+    version='3.1.0',
     packages=["workshop"],
     url='https://github.com/ververica/flink-statefun-workshop',
     license='https://www.apache.org/licenses/LICENSE-2.0',
@@ -35,7 +35,7 @@ setup(
     description='Workshop exercises for Apache Flink Stateful Functions',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    install_requires=['apache-flink-statefun==3.0.0',
+    install_requires=['apache-flink-statefun==3.1.0',
                       'aiohttp==3.7.4.post0'],
     tests_require=['pytest'],
     python_requires='>=3.8',


### PR DESCRIPTION
The only notable change is migrating `module.yaml` to the modern k8s style format. 

I also inlined the `flink-conf.yaml` so we can more easily make changes to it going forward. 